### PR TITLE
model/profile: add location information

### DIFF
--- a/.chloggen/profiles-location-folded.yaml
+++ b/.chloggen/profiles-location-folded.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+#
+# If your change doesn't affect end users you should instead start
+# your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the area of concern in the attributes-registry, (e.g. http, cloud, db)
+component: profile
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add pprof specific attribute for location.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# The values here must be integers.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/registry/attributes/profile.md
+++ b/docs/registry/attributes/profile.md
@@ -39,7 +39,16 @@ Attributes specific to pprof that helps to convert Profiling signals.
 
 | Attribute | Type | Description | Examples | Stability |
 |---|---|---|---|---|
+| <a id="profile-pprof-location" href="#profile-pprof-location">`profile.pprof.location`</a> | string | Describes the relation between symbols and a location. | `is_folded` | ![Development](https://img.shields.io/badge/-development-blue) |
 | <a id="profile-pprof-mapping" href="#profile-pprof-mapping">`profile.pprof.mapping`</a> | string | Describes the resolution of symbolic information. | `has_filenames` | ![Development](https://img.shields.io/badge/-development-blue) |
+
+---
+
+`profile.pprof.location` has the following list of well-known values. If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.
+
+| Value  | Description | Stability |
+|---|---|---|
+| `is_folded` | Provides an indication that multiple symbols map to this location's address, for example due to identical code folding by the linker. In that case the line information represents one of the multiple symbols. This field must be recomputed when the symbolization state of the profile changes. | ![Development](https://img.shields.io/badge/-development-blue) |
 
 ---
 

--- a/model/profile/common.yaml
+++ b/model/profile/common.yaml
@@ -14,3 +14,5 @@ groups:
     attributes:
       - ref: profile.pprof.mapping
         requirement_level: recommended
+      - ref: profile.pprof.location
+        requirement_level: recommended

--- a/model/profile/registry.yaml
+++ b/model/profile/registry.yaml
@@ -111,3 +111,19 @@ groups:
                 Indicates that there are inlined frames related to this mapping.
               value: "has_inline_frames"
               stability: development
+      - id: profile.pprof.location
+        stability: development
+        brief: >
+          Describes the relation between symbols and a location.
+        examples: ['is_folded']
+        type:
+          members:
+            - id: has_functions
+              brief: >
+                Provides an indication that multiple symbols map to this location's
+                address, for example due to identical code folding by the linker. In
+                that case the line information represents one of the multiple symbols.
+                This field must be recomputed when the symbolization state of the
+                profile changes.
+              value: "is_folded"
+              stability: development

--- a/model/profile/registry.yaml
+++ b/model/profile/registry.yaml
@@ -118,7 +118,7 @@ groups:
         examples: ['is_folded']
         type:
           members:
-            - id: has_functions
+            - id: is_folded
               brief: >
                 Provides an indication that multiple symbols map to this location's
                 address, for example due to identical code folding by the linker. In


### PR DESCRIPTION
## Changes

Add Profiling specific attributes for pprof location.

This change is based on top of https://github.com/open-telemetry/semantic-conventions/pull/2522 to not conflict with `registry.profile.pprof`.

FYI: @open-telemetry/profiling-approvers

## Merge requirement checklist

* [x] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [x] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
